### PR TITLE
Remove a warning about redefining #mu_pp.

### DIFF
--- a/lib/minitest/pretty_diff.rb
+++ b/lib/minitest/pretty_diff.rb
@@ -3,6 +3,7 @@ require "json"
 module MiniTest
   module Assertions
 
+    undef mu_pp if defined? "mu_pp"
     #
     # Returns a pretty-printed version of +obj+.
     #


### PR DESCRIPTION
Silencing a warning when this is used.
